### PR TITLE
Keep track of route in storage

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <title>Metro Stop Checker</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="shortcut icon" type="image/jpg" href="favicon.png"/>
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/server/public/main.js
+++ b/server/public/main.js
@@ -86,6 +86,7 @@ function setRoute() {
     let routeId = elem.value;
     if (routeId && routeId > 1 && routeId < 1000) {
         route = routeId;
+        setRouteInStorage();
         updateTimes();
     }
 }
@@ -169,13 +170,34 @@ function getStopsFromStorage() {
     }
 }
 
+function setRouteInStorage() {
+    let data = JSON.stringify(route);
+    localStorage.setItem('route', data);
+}
+
+function getRouteFromStorage() {
+    const data = localStorage.getItem('route');
+    if (data) {
+        route = JSON.parse(data);
+    }
+}
+
+function setRouteInputElem() {
+    if (route) {
+        const routeInputElem = document.getElementById('routeIdInput');
+        routeInputElem.value = route;
+        updateTimes();
+    }
+}
+
 function setLoadingIcon(loading) {
-    // debugger;
     let loadingElem = document.getElementById('updateLoading');
     loadingElem.hidden = !loading;
 }
 
 window.onload = function () {
     getStopsFromStorage();
+    getRouteFromStorage();
+    setRouteInputElem();
     updateListFromStops();
 }


### PR DESCRIPTION
Right now, stops are stored in localStorage, but not route. This leads to weird behavior when loading the app, since stops are stored with the previously set route, while route does not appear to be set.

To remedy this, route should be stored in localStorage as well, so everything is kept in sync.

Also adding a meta viewport tag to the head to fix sizing on mobile.